### PR TITLE
A few correction for chapter 4

### DIFF
--- a/content/04_memory.ipynb
+++ b/content/04_memory.ipynb
@@ -56,7 +56,7 @@
     "        \n",
     "    def access(self, offset, size): return self.memory[offset:offset+size]\n",
     "    def load  (self, offset):       return self.access(offset, 32)\n",
-    "    def store (self, offset, value): self.memory[offset:len(value)] = value"
+    "    def store (self, offset, value): self.memory[offset:offset+len(value)] = value"
    ]
   },
   {
@@ -86,7 +86,7 @@
     "    def store(self, offset, value):\n",
     "        memory_expansion_cost = 0\n",
     "        \n",
-    "        if len(self.memory) <= offset:\n",
+    "        if len(self.memory) <= offset + len(value):\n",
     "            \n",
     "            expansion_size = 0\n",
     "            \n",
@@ -96,9 +96,9 @@
     "                self.memory = [0x00 for _ in range(32)]\n",
     "                \n",
     "            # extend memory more if needed\n",
-    "            if len(self.memory) - offset < 0:\n",
-    "                expansion_size += offset - len(self.memory)\n",
-    "                self.memory.append(0x00 * expansion_size)\n",
+    "            if len(self.memory) < offset + len(value):\n",
+    "                expansion_size += offset + len(value) - len(self.memory)\n",
+    "                self.memory.extend([0x00] * expansion_size)\n",
     "                \n",
     "            memory_expansion_cost = expansion_size**2 # simplified!\n",
     "                \n",


### PR DESCRIPTION
I noticed a few oversight in python code of chapter 4, so I took the liberty of just sending a PR rather than open an issue, hope u don't mind 

In SimpleMemory:
- function store: assigning to python slice is list[n:n+size] not list[n:size]

In Memory:
- largest stored element is at index offset + len(value) so we have to use it instead of just offset
- append only add one element to a list, to add multiple element we need to use the method extend 
    - 0x00 is a byte and will be casted as int by the multiplication returning 0, to created a expansion_size long list we need to make it a one long list by adding []
    - python is so flexible this line is actually useless (hence why it
      worked previously)