### PR TITLE
Fix: Correct variable name in pos_or_neg lambda function

### DIFF
--- a/content/07a_opcodes/02_math.ipynb
+++ b/content/07a_opcodes/02_math.ipynb
@@ -123,7 +123,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pos_or_neg = lambda number: -1 if value < 0 else 1"
+    "pos_or_neg = lambda number: -1 if number < 0 else 1"
    ]
   },
   {


### PR DESCRIPTION
- Changed `value` to `number` to properly reference the input parameter and ensure correct functionality.