### PR TITLE
fix in content/07a_opcodes/02_math.ipynb

### DIFF
--- a/content/07a_opcodes/02_math.ipynb
+++ b/content/07a_opcodes/02_math.ipynb
@@ -195,7 +195,7 @@
     "def mulmod(evm):\n",
     "    a, b = evm.stack.pop(), evm.stack.pop()\n",
     "    N = evm.stack.pop()\n",
-    "    evm.stack.push((a + b) * N)\n",
+    "    evm.stack.push((a * b) % N)\n",
     "    evm.pc += 1\n",
     "    evm.gas_dec(8)"
    ]


### PR DESCRIPTION
In the function `mulmod(evm)`
```
def mulmod(evm):
    a, b = evm.stack.pop(), evm.stack.pop()
    N = evm.stack.pop()
    evm.stack.push((a + b) * N)
    evm.pc += 1
    evm.gas_dec(8)
```
this part `evm.stack.push((a + b) * N)` should be `evm.stack.push((a * b) % N)`