### PR TITLE
Add _page opcode page title to display on web

### DIFF
--- a/content/07a_opcodes/12_push.ipynb
+++ b/content/07a_opcodes/12_push.ipynb
@@ -1,6 +1,22 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "a3456fcb",
+   "metadata": {},
+   "source": [
+    "# Push"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6df5a45",
+   "metadata": {},
+   "source": [
+    "Push items to the EVM stack."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "id": "b80b0357",


### PR DESCRIPTION
The page [12_push.ipynb](https://github.com/shafu0x/evm-from-scratch-book/blob/main/content/07a_opcodes/12_push.ipynb) doesn't display properly on the web because it has no title. 

<img width="1154" height="724" alt="image" src="https://github.com/user-attachments/assets/53e2ed95-7997-407b-a400-ec87aeca48f6" />

I added a title and short description on _push function  so that it would be displayed in the menu on the left.
