### PR TITLE
Fix memory offset range description in 04_memory.ipynb

### DIFF
--- a/content/04_memory.ipynb
+++ b/content/04_memory.ipynb
@@ -41,7 +41,7 @@
    "source": [
     "We will represent Memory as a simple list that can be accessed by an index or `offset`. \n",
     "\n",
-    "An offset of `2` would mean that we get the byte stored at index `2`. Combined with a `size` we can get a block of bytes. Offset `2` and size `5` would return the bytes from index `2` to index `7`."
+    "An offset of `2` would mean that we get the byte stored at index `2`. Combined with a `size` we can get a block of bytes. Offset `2` and size `5` would return the bytes from index `2` to index `6`."
    ]
   },
   {


### PR DESCRIPTION
## Problem
The memory access explanation in `04_memory.ipynb` contained an incorrect statement about array indexing. 

The text stated that "Offset `2` and size `5` would return the bytes from index `2` to index `7`", but this is incorrect.

Fixed the description to correctly state that "Offset `2` and size `5` would return the bytes from index `2` to index `6`".
