### PR TITLE
fix(smod): remainder sign follows dividend per Yellow Paper

### DIFF
--- a/content/07a_opcodes/02_math.ipynb
+++ b/content/07a_opcodes/02_math.ipynb
@@ -135,7 +135,7 @@
    "source": [
     "def sdiv(evm):\n",
     "    a, b = evm.stack.pop(), evm.stack.pop()\n",
-    "    sign = -1 if a < 0 else 1  # sign of dividend only\n",
+    "    sign = pos_or_neg(a*b)\n",
     "    evm.stack.push(0 if b == 0 else sign * (abs(a) // abs(b)))\n",
     "    evm.pc += 1\n",
     "    evm.gas_dec(5)"
@@ -164,7 +164,7 @@
    "source": [
     "def smod(evm):\n",
     "    a, b = evm.stack.pop(), evm.stack.pop()\n",
-    "    sign = pos_or_neg(a*b)\n",
+    "    sign = -1 if a < 0 else 1  # sign of dividend only\n",
     "    evm.stack.push(0 if b == 0 else abs(a) % abs(b) * sign)\n",
     "    evm.pc += 1\n",
     "    evm.gas_dec(5)"


### PR DESCRIPTION
Mistakenly in earlier commit , I modified sdiv, instead of smod. 